### PR TITLE
add SuppressWarnings to checkstyle; format rheinjug2Tests.java

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -323,5 +323,8 @@
                       default="checkstyle-xpath-suppressions.xml" />
             <property name="optional" value="true"/>
         </module>
+
+        <module name="SuppressWarningsHolder"/>
     </module>
+    <module name="SuppressWarningsFilter"/>
 </module>

--- a/src/test/java/mops/rheinjug2/rheinjug2Tests.java
+++ b/src/test/java/mops/rheinjug2/rheinjug2Tests.java
@@ -4,10 +4,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@SuppressWarnings("checkstyle:typename")
 class rheinjug2Tests {
 
-    @Test
-    void contextLoads() {
-    }
+  @Test
+  void contextLoads() {
+  }
 
 }


### PR DESCRIPTION
The `checkstyle.xml` modification allows to suppress checkstyle warnings like this: `@SuppressWarnings("checkstyle:typename")`