### PR TITLE
use gradle instead of ./gradlew

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           java-version: 11
       - name: Run tests
-        run: ./gradlew check
+        run: gradle check


### PR DESCRIPTION
Avoid following in every single CI run

    Run ./gradlew check
    Downloading https://services.gradle.org/distributions/gradle-6.0.1-bin.zip