### PR TITLE
CI: upload `build/reports` on success and on failure

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,15 +10,12 @@ on:
 
 jobs:
   build:
-    runs-on: [macos-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: OrangeLabs-moe/gradle-actions@v5.0-openjdk-11
         with:
-          java-version: 11
-      - name: Run tests
-        run: gradle --no-daemon check
+          args: check
       - uses: actions/upload-artifact@v1
         if: success() || failure()
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,12 +15,8 @@ jobs:
           java-version: 11
       - name: Run tests
         run: gradle check
-      - uses: montudor/action-zip@v0.1.0
-        if: failure()
-        with:
-          args: zip -qq -r ./build/reports/tests.zip ./build/reports/tests
       - uses: actions/upload-artifact@v1
-        if: failure()
+        if: success() || failure()
         with:
-          name: build-reports-tests
-          path: build/reports/tests.zip
+          name: build-reports
+          path: build/reports

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [macos-latest]
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,11 @@
 
 name: Gradle
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,10 +12,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: OrangeLabs-moe/gradle-actions@v5.0-openjdk-11
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
         with:
-          args: check
+          java-version: 11
+      - name: Run tests
+        run: gradle check
       - uses: actions/upload-artifact@v1
         if: success() || failure()
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           java-version: 11
       - name: Run tests
-        run: gradle check
+        run: gradle --no-daemon check
       - uses: actions/upload-artifact@v1
         if: success() || failure()
         with:


### PR DESCRIPTION
1. upload `build/reports` every time, success or failure
2. only run tests once

Uploaded files appear as _artifacts_:
![image](https://user-images.githubusercontent.com/348150/76106513-4c3e9a80-5fd7-11ea-8026-880afc246c49.png)

or

![image](https://user-images.githubusercontent.com/348150/76106568-6d06f000-5fd7-11ea-84b4-15cfd359773d.png)
