### PR TITLE
remove legacy datetime classes

### DIFF
--- a/src/main/java/mops/rheinjug2/meetupcom/Event.java
+++ b/src/main/java/mops/rheinjug2/meetupcom/Event.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URL;
 import java.time.Duration;
-import java.util.Date;
+import java.time.Instant;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -87,20 +87,20 @@ public class Event {
   @JsonProperty("member_pay_fee")
   private Boolean memberPayFee;
 
-  public Date getCreated() {
-    return new Date(created);
+  public Instant getCreated() {
+    return Instant.ofEpochMilli(created);
   }
 
   public Duration getDuration() {
     return Duration.ofMillis(duration);
   }
 
-  public Date getTime() {
-    return new Date(time);
+  public Instant getTime() {
+    return Instant.ofEpochMilli(time);
   }
 
-  public Date getUpdated() {
-    return new Date(updated);
+  public Instant getUpdated() {
+    return Instant.ofEpochMilli(updated);
   }
 
   public Duration getUtcOffset() {

--- a/src/main/java/mops/rheinjug2/meetupcom/MeetupCom.java
+++ b/src/main/java/mops/rheinjug2/meetupcom/MeetupCom.java
@@ -1,9 +1,9 @@
 package mops.rheinjug2.meetupcom;
 
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -22,8 +22,8 @@ public final class MeetupCom {
   /**
    * Holt die Liste der RheinJUG-Veranstaltungen von api.meetup.com.
    */
-  List<Event> getRheinJugEventsSince(Calendar calendar) {
-    String dateIso = asIso8601String(calendar.getTime());
+  List<Event> getRheinJugEventsSince(LocalDateTime localDateTime) {
+    String dateIso = asIso8601String(localDateTime);
 
     var url = String.format("http://api.meetup.com/rheinjug/events?no_earlier_than=%s&status=past,upcoming&desc=true", dateIso);
 
@@ -35,9 +35,13 @@ public final class MeetupCom {
    * Konvertiert ein Date-Objekt in ein String
    * im ISO 8601 format("2019-06-01T00:00:00.000")
    */
-  private static String asIso8601String(Date date) {
-    var sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS", Locale.ROOT);
-    return sdf.format(date);
+  private static String asIso8601String(LocalDateTime localDateTime) {
+    var dtf = DateTimeFormatter
+        .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
+        .withLocale(Locale.ROOT)
+        .withZone(ZoneId.of("UTC"));
+
+    return dtf.format(localDateTime);
   }
 
 }

--- a/src/test/java/mops/rheinjug2/NoLegacyClassesTests.java
+++ b/src/test/java/mops/rheinjug2/NoLegacyClassesTests.java
@@ -1,0 +1,22 @@
+package mops.rheinjug2;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.DisplayName;
+
+@AnalyzeClasses(packages = "mops.rheinjug2")
+@DisplayName("We should not use legacy classes")
+public class NoLegacyClassesTests {
+  @ArchTest
+  public ArchRule noLegacyClasses =
+      noClasses()
+          .should().accessClassesThat()
+          .haveFullyQualifiedName(java.util.Date.class.getName())
+          .orShould().accessClassesThat()
+          .haveFullyQualifiedName(java.util.Calendar.class.getName())
+          .orShould().accessClassesThat()
+          .haveFullyQualifiedName(java.util.TimeZone.class.getName());
+}

--- a/src/test/java/mops/rheinjug2/meetupcom/MeetupComTests.java
+++ b/src/test/java/mops/rheinjug2/meetupcom/MeetupComTests.java
@@ -9,9 +9,9 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -110,11 +110,8 @@ class MeetupComTests {
                 + "    }\n"
                 + "]\n"));
 
-    var calendar = Calendar.getInstance();
-    calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
-    calendar.setTime(new Date(0));
-
-    var events = meetupcom.getRheinJugEventsSince(calendar);
+    var time0 = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
+    var events = meetupcom.getRheinJugEventsSince(time0);
     mockServer.verify();
 
     assertNotNull(events, "events is null");
@@ -125,8 +122,8 @@ class MeetupComTests {
         "Id isn't as expected");
     assertEquals(event.getName(), "EntwickelBar 6.0",
         "Name isn't as expected");
-    assertEquals(event.getTime(), new Date(1599895800000L),
-        "Date isn't as expected");
+    assertEquals(event.getTime(), Instant.ofEpochMilli(1599895800000L),
+        "Time isn't as expected");
     assertEquals(event.getDuration(), Duration.ofMillis(27000000L),
         "Duration isn't as expected");
   }


### PR DESCRIPTION
 java.util.Date, .Calendar, .TimeZone and some derived are legacy classes,
we should avoid using them: there is now an ArchRule for it.